### PR TITLE
Update orb exit, add fresh hops, update readme

### DIFF
--- a/Individual_Levels.json
+++ b/Individual_Levels.json
@@ -51,8 +51,8 @@
             "next": [
                 {
                     "address": "0x1493",
-                    "value": "0xFF",
-                    "type": "eq"
+                    "value": "0xf0",
+                    "type": "gt"
                 }
             ],
             "_comment": "Triggers on Orb in Vertical Level"

--- a/Love Yourself.json
+++ b/Love Yourself.json
@@ -44,8 +44,8 @@
             "next": [
                 {
                     "address": "0x1493",
-                    "value": "0xFF",
-                    "type": "eq"
+                    "value": "0xF0",
+                    "type": "gt"
                 }
             ],
             "_comment": "Triggers on Orb in Vertical Level"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Check out their work here: https://github.com/usb2snes/LiveSplit.USB2SNESSplitte
 - Fxpak Pro (Install firmware based on these instructions: http://usb2snes.com/)
 - SNES Classic (See installation guide here: https://github.com/Skarsnik/QUsb2snes/blob/master/README.md#snes-classic-called-also-snes-mini)
 
+## Unsupported, but possible to work
+- QUSB2SNES software running, set up for LUA Bridge (Deprecated)
+- SNES9x-rr - a fork of SNES9x with support for Lua Scripts (Sorry retroarch players) (https://github.com/gocha/snes9x-rr/releases)
+
 # Installation
 
 - Copy "LiveSplit.USB2SNESSplitter.dll" to your LiveSplit-folder "LiveSplit/Components"

--- a/RomHackRaces.json
+++ b/RomHackRaces.json
@@ -1,5 +1,6 @@
 {
     "name": "Romhack Races",
+    "_comment": "Made this in an attempt to have an autosplit config for any level the HR folks might send at us. might require knowing how the level exits.",
     "autostart": {
         "active": "1",
         "address": "0x0100",
@@ -35,6 +36,20 @@
             "value": "0x0030",
             "type": "eq",
             "_comment": "Triggers on the key in the keyhole audio"
+        },
+        {
+            "name": "Orb Exit",
+            "address": "0x1493",
+            "value": "0x00",
+            "type": "eq",
+            "next": [
+                {
+                    "address": "0x1493",
+                    "value": "0xFF",
+                    "type": "eq"
+                }
+            ],
+            "_comment": "Triggers on Orb in Vertical Level"
         },
         {
             "name": "Boss Exit",

--- a/freshhops.json
+++ b/freshhops.json
@@ -1,0 +1,88 @@
+{
+	"name": "Fresh Hops",
+	"_by": "MorrieTheMagpie",
+	"_credit": "pzyko103, chsbrgr",
+	"autostart": {
+		"active": "1",
+		"address": "0x100",
+		"value": "0x08",
+		"type": "eq",
+		"next": [
+			{
+				"address": "0x0100",
+				"value": "0x0a",
+				"type": "gt"
+			}
+		]
+	},
+	"definitions": [
+		{
+			"name": "Normal Exit",
+			"address": "0x1B99",
+			"value": "0x01",
+			"type": "eq",
+			"next": [
+				{
+					"address": "0x1B99",
+					"value": "0x00",
+					"type": "eq"
+				}
+			]
+		},
+		{
+			"name": "Boss Exit",
+			"address": "0x13C6",
+			"value": "0xFF",
+			"type": "eq"
+		},
+		{
+			"name": "Fanfare",
+			"address": "0x906",
+			"value": "0x00",
+			"type": "eq",
+			"next": [
+				{
+					"address": "0x906",
+					"value": "0x01",
+					"type": "eq"
+				}
+			]
+		},
+		{
+            "name": "Orb Exit",
+            "address": "0x1493",
+            "value": "0x00",
+            "type": "eq",
+            "next": [
+                {
+                    "address": "0x1493",
+                    "value": "0xF0",
+                    "type": "gt"
+                }
+            ],
+            "_comment": "Triggers on Orb in Vertical Level"
+        },
+		{
+			"name": "Key Exit",
+			"address": "0x1434",
+			"value": "0x0030",
+			"type": "eq"
+		}
+	],
+	"alias": {
+		"Huma Lupa Licious": "Normal Exit",
+		"Bellaire Brown": "Normal Exit",
+		"Falls Tannen": "Normal Exit",
+		"Diabolical": "Boss Exit",
+		"Presque Ale": "Normal Exit",
+		"Serendipity": "Normal Exit",
+		"Low Hanging Fruit": "Normal Exit",
+		"Two Hearted": "Normal Exit",
+		"Blooming Desert": "Boss Exit",
+		"Rubaeus": "Normal Exit",
+		"Laughing Fish": "Normal Exit",
+		"Borealis Broo": "Normal Exit",
+		"Barbaric Yawp": "Orb Exit",
+		"Widowmaker": "Boss Exit"
+	}
+}


### PR DESCRIPTION
Updated Orb Exits to look for Greater Than F0, instead of Equal To FF. Found that QUSB2SNES+aplitter would only intermittently work on old def. This is likely due to how fast QUSB2SNES can allow the autosplittler to poll the game memory of the FXPak Pro.

Added Fresh Hops by MorrieTheMagpie. Thanks to Pzyko103 for doing 99.9% of the work, also leading to the "greater than F0" change.

Updated the ReadMe to clarify there is an unsupported, but working
method for splitting with the qusb2snes and lua bridge with snes9x-rr.
linked to SNES9X-rr repo