### PR TITLE
Added an alias for 'Two-Hearted' in addition to 'Two Hearted'.

### DIFF
--- a/freshhops.json
+++ b/freshhops.json
@@ -78,6 +78,7 @@
 		"Serendipity": "Normal Exit",
 		"Low Hanging Fruit": "Normal Exit",
 		"Two Hearted": "Normal Exit",
+		"Two-Hearted": "Normal Exit",
 		"Blooming Desert": "Boss Exit",
 		"Rubaeus": "Normal Exit",
 		"Laughing Fish": "Normal Exit",


### PR DESCRIPTION
Just a small commit to add an alias for the level "Two-Hearted". In the original there is only an alias for "Two Hearted".